### PR TITLE
Replace placeholder license and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,35 @@
-ECHO is on.
+# OS-generated files
+.DS_Store
+Thumbs.db
+
+# Editor backups
+*~
+*.swp
+
+# Logs and temporary files
+*.log
+*.tmp
+tmp/
+
+# Build directories
+build/
+_build/
+dist/
+site/
+public/
+
+# Sphinx documentation build
+/docs/_build/
+/docs/build/
+
+# Virtual environments
+venv/
+.env/
+.venv/
+
+# Node dependencies
+node_modules/
+
+# IDE configuration
+.idea/
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-ECHO is on.
+MIT License
+
+Copyright (c) 2025 Arathia Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add an MIT License as the project's LICENSE file
- fill in `.gitignore` with standard patterns for documentation builds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d2f460bec832987a360120796c58a