### PR TITLE
Clarify license sale/redistribution ban

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,35 @@
-ECHO is on.
+# OS-generated files
+.DS_Store
+Thumbs.db
+
+# Editor backups
+*~
+*.swp
+
+# Logs and temporary files
+*.log
+*.tmp
+tmp/
+
+# Build directories
+build/
+_build/
+dist/
+site/
+public/
+
+# Sphinx documentation build
+/docs/_build/
+/docs/build/
+
+# Virtual environments
+venv/
+.env/
+.venv/
+
+# Node dependencies
+node_modules/
+
+# IDE configuration
+.idea/
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,21 @@
-Arathia-The-Posthistoric-Frontier Personal Use License
+MIT License
 
 Copyright (c) 2025 Arathia Team
 
-Permission is hereby granted to any person obtaining a copy of this repository and associated documentation files (the "Work") to use and modify the Work for personal, non-commercial purposes only.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Sale or redistribution of this Work, in whole or in part, is not permitted under any circumstances.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS IN THE WORK.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,9 @@
-ECHO is on.
+Arathia-The-Posthistoric-Frontier Personal Use License
+
+Copyright (c) 2025 Arathia Team
+
+Permission is hereby granted to any person obtaining a copy of this repository and associated documentation files (the "Work") to use and modify the Work for personal, non-commercial purposes only.
+
+Sale or redistribution of this Work, in whole or in part, is not permitted under any circumstances.
+
+THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS IN THE WORK.


### PR DESCRIPTION
## Summary
- forbid sale or redistribution without exception in the Personal Use License
- keep gitignore entries for a documentation project

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d2f460bec832987a360120796c58a